### PR TITLE
Responsive article grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,16 @@
 			article {
 				padding: 2rem;
 			}
+			articlegrid {
+				grid-template-columns: 1fr 1fr;
+				grid-gap: 2rem;
+				display: grid;
+			}
+			@media (max-width: 700px) {
+				articlegrid {
+					grid-template-columns: 1fr;
+				}
+			}
 		</style>
 	</head>
 	<body>
@@ -73,13 +83,7 @@
 					<h1>Features</h1>
 					<p></p>
 				</header>
-				<div
-					style="
-						grid-template-columns: 1fr 1fr;
-						grid-gap: 2rem;
-						display: grid;
-					"
-				>
+				<articlegrid>
 					<article>
 						<h2>Use only HTML</h2>
 						<p>
@@ -111,7 +115,7 @@
 						<h2>No classes</h2>
 						<p>No classes to make your code more readable.</p>
 					</article>
-				</div>
+				</articlegrid>
 			</section>
 		</main>
 		<footer>


### PR DESCRIPTION
This PR added the following CSS code:
```css
@media (max-width: 700px) {
	articlegrid {
		grid-template-columns: 1fr;
	}
}
```
This changes the amount of columns from two to one on small devices (technically, width <= 700px) like mobile phones. Note that the inline CSSes of the grid are now replaced by those in the `<head>` element. 

Here is a demo: https://mtccs.thost3.de/ (This demo uses seperated stylesheet, https://mtccs.thost3.de/main.css, instead of `<style>` in `<head>`.)